### PR TITLE
🔌 Add submodule for pyglotaran release paper

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "2023-05-van_Stokkum_et_al"]
 	path = 2023-05-van_Stokkum_et_al
 	url = https://github.com/glotaran/pub-2023-05-van_Stokkum_et_al.git
+[submodule "2023-pyglotaran-release-paper"]
+	path = 2023-pyglotaran-release-paper
+	url = https://github.com/glotaran/pyglotaran-release-paper-supplementary-information


### PR DESCRIPTION
A new submodule has been added to the project to include supplementary information for the pyglotaran release paper. The submodule is located at `2023-pyglotaran-release-paper` and points to a GitHub repository containing the supplementary information.

